### PR TITLE
Fix should-update? only updating when false

### DIFF
--- a/src/fn_fx/diff.clj
+++ b/src/fn_fx/diff.clj
@@ -42,10 +42,10 @@
   (let [{:keys [props]} to]
     (if (and (= (:type from) (:type to))
              (should-update? to (:props from) props))
-      (do (set-once! to :render-result (:render-result from))
-          false)
       (do (set-once! to :render-result nil)
-          true))))
+          true)
+      (do (set-once! to :render-result (:render-result from))
+          false))))
 
 
 (defn diff-child-list [dom parent-node k a-list b-list]
@@ -152,7 +152,7 @@
                        ~@mp
                        ~@(when (not @has-should-update?)
                            `[(should-update? [this# old-props# new-props#]
-                                           (= old-props# new-props#))]))
+                                           (not= old-props# new-props#))]))
          (defn ~fn-name
            ([] (~fn-name {}))
            ([k# v# & props#]

--- a/test/fn_fx/diff_test.clj
+++ b/test/fn_fx/diff_test.clj
@@ -249,7 +249,7 @@
           rendered? (atom false)
           first (always-updating :rendered? rendered?)]
       (is (= (->Created 1) (diff log nil first)))
-      (is @rendered?)
+      (is (= true @rendered?))
 
       (is (= @log {:id 1
 
@@ -258,8 +258,8 @@
 
       (reset! rendered? false)
 
-      (is (= (->Noop 1) (diff log first (always-updating :rendered? rendered?))))
-      (is rendered? true)
+      (is (= (->Updated 1) (diff log first (always-updating :rendered? rendered?))))
+      (is (= true @rendered?))
 
       (is (= @log {:id 1
                    :log [[:create 1 :button]


### PR DESCRIPTION
While working with fn-fx I noticed that when I provided a custom `should-update?` that always returned true, my component would not update. If I changed that value to false, it would. I looked and noticed a test that was supposed to handle this case and noticed a mistake in the test. My first commit fixes that mistake. If you checkout that commit you will see after the mistake is fixed, that test fails.

My second commit fixes there error.  Essentially, the condition for `needs-update?` was inverted, but so was the default `should-update?` so the bug only manifested itself with a custom `should-update?`

Hopefully all this is clear, if there is anything else I need to do let me know. I tried to follow the contributing guidelines as close as I could.