### PR TITLE
Upgrade dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,16 +23,16 @@
   :min-lein-version    "2.8.1"
   :repositories        [["sonatype-snapshots" {:url "https://oss.sonatype.org/content/groups/public" :snapshots true}]
                         ["jcenter"            {:url "https://jcenter.bintray.com/" :snapshots false}]]
-  :dependencies        [[org.clojure/clojure         "1.9.0"]
+  :dependencies        [[org.clojure/clojure         "1.10.0"]
                         [org.reflections/reflections "0.9.11"]]
   :profiles            {:dev            {:source-paths ["src" "examples"]
-                                         :dependencies [[com.github.javaparser/javaparser-core "3.7.0"]]
+                                         :dependencies [[com.github.javaparser/javaparser-core "3.9.0"]]
                                          :plugins      [[lein-release  "1.1.3"]
                                                         [lein-licenses "0.2.2"]
                                                         [lein-codox    "0.10.5"]]}
                         :1.8            {:dependencies [[org.clojure/clojure "1.8.0"]]}
                         :1.9            {:dependencies [[org.clojure/clojure "1.9.0"]]}
-                        :1.10           {:dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]]}
+                        :1.10           {:dependencies [[org.clojure/clojure "1.10.0"]]}
                         :openjfx11      ^:leaky   ; Ensure these dependencies "leak" through to the POM and JAR tasks
                                         {:dependencies [[org.openjfx/javafx-controls "11.0.1"]
                                                         [org.openjfx/javafx-swing    "11.0.1"]


### PR DESCRIPTION
With the release of Clojure 1.10, it seems like a good time to upgrade all out of date dependencies.